### PR TITLE
Add -I flag in hera_snap_feng_init.py

### DIFF
--- a/control_software/scripts/hera_snap_feng_init.py
+++ b/control_software/scripts/hera_snap_feng_init.py
@@ -24,8 +24,11 @@ parser.add_argument('-s', dest='sync', action='store_true', default=False,
                     help ='Use this flag to sync the F-engine(s) and Noise generators from PPS')
 parser.add_argument('-m', dest='mansync', action='store_true', default=False,
                     help ='Use this flag to manually sync the F-engines with an asynchronous software trigger')
-parser.add_argument('-i', dest='initialize', action='store_true', default=False,
-                    help ='Use this flag to initialize the F-engine(s)')
+group_init = parser.add_mutually_exclusive_group()
+group_init.add_argument('-i', dest='fast_initialize', action='store_true', default=None,
+                    help ='Use this flag to initialize the uninitialized F-engine(s)')
+group_init.add_argument('-I', dest='fast_initialize', action='store_false', default=None,
+                    help ='Use this flag to initialize all F-engine(s)')
 parser.add_argument('-t', dest='tvg', action='store_true', default=False,
                     help ='Use this flag to switch to EQ TVG outputs')
 parser.add_argument('-n', dest='noise', action='store_true', default=False,
@@ -71,12 +74,12 @@ time.sleep(1) # wait for the monitor to pause
 
 if args.program or args.forceprogram:
     corr.program(unprogrammed_only=(not args.forceprogram)) # This should multithread the programming process.
-    if not args.initialize:
+    if args.initialize is None:
         logger.warning('Programming but *NOT* initializing. This is unlikely to be what you want')
 
-if args.initialize:
+if args.fast_initialize is not None:
     corr.disable_output()
-    corr.initialize(multithread=(not args.nomultithread))
+    corr.initialize(multithread=(not args.nomultithread), uninitialized_only=args.fast_initialize)
 
 if args.tvg:
     logger.info('Enabling EQ TVGs...')

--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -91,7 +91,7 @@ class Synth(casperfpga.synth.LMX2581):
         pass
 
 class Adc(casperfpga.snapadc.SNAPADC):
-    def __init__(self, host, sample_rate=500, num_chans=2, resolution=8, ref=10, logger=None):
+    def __init__(self, host, sample_rate=500, num_chans=2, resolution=8, ref=10, logger=None, **kwargs):
         """
         Instantiate an ADC block.
         
@@ -111,6 +111,8 @@ class Adc(casperfpga.snapadc.SNAPADC):
         self.sample_rate     = sample_rate
         self.resolution      = resolution
         self.host = host # the SNAPADC class doesn't directly expose this
+        self._retry = kwargs.get('retry',3)
+        self._retry_wait = kwargs.get('retry_wait',1)
 
     def set_gain(self, gain):
         """
@@ -144,22 +146,26 @@ class Adc(casperfpga.snapadc.SNAPADC):
         """
         Initialize the configuration of the ADC chip.
         """
-        n_retries = 3
-        for i in range(n_retries):
-            if self.init(self.sample_rate, self.num_chans) == self.SUCCESS:
+        for i in range(self._retry):
+            if self.init(self.sample_rate, self.num_chans):
                 if i == 0:
                     self.logger.info("ADC configured OK")
                 if i > 0:
                     self.logger.warning("ADC took %d attempts to configure" % (i+1))
                 break
-            if i == n_retries - 1:
+            if i == self._retry - 1:
                 self.logger.error("ADC failed to configure after %d attempts" % (i+1))
+
+        if not self.rampTest():
+            self.logger.warning('ADC failed on ramp test')
+
         #self.alignLineClock(mode='dual_pat')
         #self.alignFrameClock()
         ##If aligning complete, alignFrameClock should not output any warning
         self.selectADC()
         self.adc.selectInput([1,1,3,3])
         self.set_gain(4)
+        return True
 
 class Sync(Block):
     def __init__(self, host, name):

--- a/control_software/src/snap_fengine.py
+++ b/control_software/src/snap_fengine.py
@@ -89,6 +89,9 @@ class SnapFengine(object):
             self.logger.info("Initializing block: %s" % block.name)
             block.initialize()
 
+    def is_initialized(self):
+        return self.i2c_initialized
+
     def get_fpga_stats(self):
         """
         Get FPGA stats.


### PR DESCRIPTION
Change -i flags in hera_snap_feng_init.py so that it skips F-Engine that has already been initialised
Add -I flag, which initialised all F-Engines.

The change in src/blocks.py line 149 relies on https://github.com/HERA-Team/casperfpga/pull/2, in which init() returns True instead of self.SUCCESS