### PR TITLE
Fem switch script

### DIFF
--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
     if args.filename is not None:
         filename = os.path.join(args.output, args.filename)
         pio.write_html(fig, auto_open=False,
-                       file='fem_switch_plot.html',
+                       file=filename,
                        )
     if args.show:
         pio.show(fig)

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -27,7 +27,7 @@ logger = helpers.add_default_log_handlers(logging.getLogger(__name__),
 
 
 def main(redishost='redishost', hostname=None, antenna_input=None,
-         integration_time=None, do_not_initialize=False, no_equalization=False):
+         integration_time=None, initilize=True, no_equalization=False):
     """Loop through input hostnames and collect spectra for all FEM switch states.
 
     Parameters
@@ -43,9 +43,11 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
         If None all antennas on a snap will be returned with spectra.
     integration_time : float
         The desired integration time in s for a spectra.
-    do_not_initialize : bool
-        Flag used to not initialize Snap boards if they are not programmed.
-        This is not a common option and should only be set if observing is underway.
+    initilize : bool
+        Flag used to initialize Snap boards even if they are already programmed.
+        Defualts to True.
+        Set to False to not initialize Snap boards on call; however this
+        is not a common option and should only be done if observing is underway.
     no_equalization : bool
         Do not divide the spectra by the the equalization coefficients
 
@@ -95,7 +97,7 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
             snap.fpga.transport.prog_user_image()
             snap.initialize()
 
-        elif not do_not_initialize:
+        elif initilize:
             # programmed Snap may sill need to be initialized
             snap.initialize()
         else:
@@ -308,7 +310,8 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--filename', dest='filename',
                         default='fem_status_plot.html',
                         help='Filename to save the plot.')
-    parser.add_argument('--do_not_initialize', action='store_true',
+    parser.add_argument('--do_not_initialize', action='store_false',
+                        dest='initilize',
                         help="Do not initialize the SNAP(s). "
                         "This is uncommon and should only be done "
                         "if observation is currently underway.")
@@ -325,7 +328,7 @@ if __name__ == "__main__":
         redishost=args.redishost, hostname=args.hostname,
         antenna_input=args.antenna_input,
         integration_time=args.integration_time,
-        do_not_initialize=args.do_not_initialize,
+        initilize=args.initilize,
         no_equalization=args.no_equalization
     )
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -168,6 +168,8 @@ def make_plot(correlations=None, snap_to_ant=None):
 
 
     """
+    hostnames = sorted(list(correlations.keys()))
+
     n_plots = len(list(correlations.values())[0].keys())
     colors = {"antenna": "blue",
               "load": "orange",
@@ -175,9 +177,19 @@ def make_plot(correlations=None, snap_to_ant=None):
               }
     cols = np.int(np.ceil(np.sqrt(n_plots)))
     rows = np.int(np.ceil(n_plots / np.float(cols)))
-    subplot_titles = ["ADC PORT {}".format(n)
-                      for n in sorted(correlations.values()[0].keys())
-                      ]
+
+    subplot_titles = []
+    for n in sorted(correlations.values()[0].keys()):
+        if snap_to_ant is not None:
+            antpol = snap_to_ant[hostnames[0]][int(n)]
+            if antpol is None:
+                antpol = 'N/C'
+            subplot_titles.append('ADC PORT {port} {antpol}'
+                                  .format(port=n, antpol=antpol)
+                                  )
+        else:
+            subplot_titles.append('ADC PORT {port}'.format(port=n))
+
     fig = subplots.make_subplots(rows=rows, cols=cols,
                                  subplot_titles=subplot_titles
                                  )
@@ -197,7 +209,6 @@ def make_plot(correlations=None, snap_to_ant=None):
     freqs = np.linspace(0, 250e6, 1024)
     freqs /= 1e6
     scatters = []
-    hostnames = sorted(list(correlations.keys()))
     for host in hostnames:
         visible = True if host == hostnames[0] else False
         for ant in sorted(correlations[host].keys()):

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -110,7 +110,7 @@ def make_plot(correlations=None):
     cols = np.int(np.ceil(np.sqrt(n_plots)))
     rows = np.int(np.ceil(n_plots / np.float(cols)))
     subplot_titles = ["ADC PORT {}".format(n)
-                      for n in sorted(correlations.values())[0].keys()
+                      for n in sorted(correlations.values()[0].keys())
                       ]
     fig = subplots.make_subplots(rows=rows, cols=cols,
                                  subplot_titles=subplot_titles
@@ -143,6 +143,7 @@ def make_plot(correlations=None):
                 _scatter = go.Scatter(x=freqs,
                                       y=autocorr,
                                       name=name,
+                                      host=host,
                                       marker={"color": colors[state],
                                               },
                                       visible=visible,
@@ -151,26 +152,19 @@ def make_plot(correlations=None):
                 scatters.append(_scatter)
                 fig.add_trace(_scatter, row=row, col=col)
 
-    # make a mask for each host
-    host_mask = []
-    for h1 in hostnames:
-        _mask = []
-        for h2 in hostnames:
-            _mask.append([True if h1 == h2 else False
-                          for ant in correlations[h2]
-                          for state in correlations[h2][ant]
-                          ])
-        host_mask.append(_mask)
-
     buttons = []
     for host_cnt, host in enumerate(hostnames):
-        _button = {"args": [{"visible": host_mask[host_cnt]},
+        visibility = [h2 == host for h2 in sorted(correlations.keys())
+                      for ant in correlations[h2]
+                      for stat in correlations[h2][ant]
+                      ]
+        _button = {"args": [{"visible": visibility},
                             {  # "title": '',
                             "annotations": {}
                              }
                             ],
                    "label": host,
-                   "method": "restyle"
+                   "method": "update"
                    }
         buttons.append(_button)
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -236,6 +236,8 @@ def make_plot(correlations=None, snap_to_ant=None):
         for port, _an in zip(sorted(correlations[host].keys()), annos):
             if snap_to_ant is not None:
                 antpol = snap_to_ant[host][int(port)]
+                if antpol is None:
+                    antpol = 'N/C'
                 _an.text = 'ADC PORT {port} {antpol}'.format(port=port,
                                                              antpol=antpol)
             else:

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2017-2019 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Loop through all FEM states for given SNAPs and antenna indices."""
+
+import os
+import sys
+import numpy as np
+import argparse
+import logging
+from hera_corr_f import HeraCorrelator, SnapFengine, helpers
+
+if sys.version_info[0] < 3:
+    # py2
+    from plotly import graph_objs as go, subplots, io as pio
+else:
+    # py3
+    from plotly import graph_objects as go, subplots, io as pio
+
+logger = helpers.add_default_log_handlers(logging.getLogger(__name__),
+                                          fglevel=logging.NOTSET)
+
+
+def main(redishost='redishost', hostname=None, antenna_input=None,
+         integration_time=None):
+
+    # not actually using the connection
+    # but will bw used tempo manipulate the monitoring state
+    # and find all hosts if needed.
+    c = HeraCorrelator(redishost=redishost,
+                       passive=True)
+    if hostname:
+        if not isinstance(hostname, (list, tuple)):
+            hostname = [hostname]
+
+        hostname = sorted(hostname)
+
+    if not hostname and not antenna_input:
+        logger.info("Using all SNAPs from redis configuration")
+        SNAP_HOST = sorted(list(c.config['fengines'].keys()))
+        ANTENNA_INPUT = np.arange(0, 6)
+    elif hostname and not antenna_input:
+        SNAP_HOST = hostname
+        ANTENNA_INPUT = np.arange(0, 6)
+    else:
+        SNAP_HOST = hostname
+        ANTENNA_INPUT = antenna_input
+
+    correlations = {}
+    for host in SNAP_HOST:
+        # Disable the monitoring process for 5 minutes,
+        # to stop it interfering with this script
+        c.disable_monitoring(300, wait=True)
+        snap = SnapFengine(SNAP_HOST, redishost=redishost)
+
+        if integration_time is not None:
+            acc_len = int(integration_time * 250e6
+                          // (snap.corr.nchans * snap.corr.spec_per_acc)
+                          )
+            if not acc_len == snap.corr.get_acc_len():
+                snap.corr.set_acc_len(acc_len)
+
+        host_group = correlations.setdefault(host, {})
+
+        for antenna_ind in ANTENNA_INPUT:
+            c.disable_monitoring(60, wait=True)
+
+            fem = snap.fems[antenna_ind]
+            current_state = fem.switch()
+
+            ant_group = host_group.setdefault(antenna_ind, {})
+
+            for state in ['noise', 'load', 'antenna']:
+                fem.switch(state)
+                autocorr = snap.corr.get_new_corr(antenna_ind, antenna_ind)
+
+                eq_coeff = snap.eq.get_coeffs(antenna_ind)
+                ant_group[state] = autocorr / eq_coeff**2
+
+            # restore this antenna to the state it started in
+            fem.switch(name=current_state[0],
+                       east=current_state[1],
+                       north=current_state[2])
+
+    # Re-enable monitoring.
+    c.enable_monitoring()
+    return correlations
+
+
+def make_plot(correlations=None):
+    n_plots = len(list(correlations.values())[0].keys())
+    cols = np.int(np.ceil(np.sqrt(n_plots)))
+    rows = np.int(np.ceil(n_plots / np.float(cols)))
+    fig = subplots.make_subplots(rows=rows, cols=cols)
+
+    # lost of nasty plotly code to make stuff
+    freqs = np.linspace(0, 250e6, 1024)
+    freqs /= 1e6
+    scatters = []
+    hostnames = sorted(list(correlations.keys()))
+    for host in hostnames:
+        visible = True if host == hostnames[0] else False
+        for ant in correlations[host]:
+            row = ant // cols + 1
+            col = ant % cols + 1
+            for state in correlations[host][ant]:
+                name = "{ant}:{state}".format(ant=ant, state=state)
+                autocorr = correlations[host][ant][state]
+                autocorr = 10 * np.log10(np.ma.masked_invalid(autocorr)
+                                         ).filled(-50)
+                _scatter = go.Scatter(x=freqs,
+                                      y=autocorr,
+                                      name=name,
+                                      row=row,
+                                      col=col,
+                                      visible=visible)
+                scatters.append(_scatter)
+                fig.add_trace(_scatter)
+
+    # make a mask for each host
+    host_mask = []
+    for h1 in hostnames:
+        _mask = []
+        for h2 in hostnames:
+            _mask.append([True if h1 == h2 else False
+                          for ant in correlations[h2]
+                          for state in correlations[h2][ant]
+                          ])
+
+    buttons = []
+    for host_cnt, host in enumerate(hostnames):
+        _button = {"args": [{"visible": host_mask[host_cnt]},
+                            {"title": '',
+                             "annotations": {}
+                             }
+                            ],
+                   "label": host,
+                   "method": "restyle"
+                   }
+        buttons.append(_button)
+
+    updatemenu = go.layout.Updatemenu(
+        buttons=buttons,
+        direction='down',
+        showactive=True,
+    )
+
+    # Finish plot
+    layout = go.Layout(showlegend=True,
+                       title='Antenna Fem switch states',
+                       updatemenus=[updatemenu]
+                       )
+    fig.update_layout(layout)
+
+    return fig
+
+
+if __name__ == "__main__":
+    desc = ('Loop through all FEM switch states ["noise", "load", "antenna"]. '
+            'Record a auto-correlation spectra from the SNAP for each state. '
+            'Can run on a single antenna when both "hostname" and "antenna_input" '
+            'are set. If "hostname" is set with no "ANTENNA_INPUT" will run on all '
+            'antennas in that SNAP. If both inputs "hostname" '
+            'and "antenna_input" are not provides, will loop through all SNAPS '
+            'and all antennas.')
+    parser = argparse.ArgumentParser(description=desc,
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument(dest='hostname', type=str, nargs='*',
+                        help='Host board to collect data from.')
+    parser.add_argument('-r', dest='redishost', type=str, default='redishost',
+                        help='Host servicing redis requests')
+    parser.add_argument('-a', '--antenna_input', dest='antenna_input',
+                        type=int, nargs='*',
+                        help="Antenna number on the SNAP to take spectra.")
+    parser.add_argument('-t', '--integration_time', type=int, default=1,
+                        help='Integration time in seconds for each spectra')
+    parser.add_argument('-o', '--output', type=str, default='.',
+                        help='Path to destination folder')
+    parser.add_argument('-f', '--filename', dest='filename',
+                        default='fem_status_plot.html',
+                        help='Filename to save the plot.')
+    parser.add_argument('--show', dest='show', action='store_true',
+                        help='Show plot.')
+
+    args = parser.parse_args()
+
+    correlations = main(
+        redishost=args.redishost, hostname=args.hostname,
+        antenna_input=args.antenna_input,
+        integration_time=args.integration_time
+    )
+
+    fig = make_plot(correlations=correlations)
+
+    if args.filename is not None:
+        filename = os.path.join(args.output, args.filename)
+        pio.write_html(fig, auto_open=False,
+                       file='fem_switch_plot.html',
+                       )
+    if args.show:
+        pio.show(fig)

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -24,7 +24,7 @@ logger = helpers.add_default_log_handlers(logging.getLogger(__name__),
 
 
 def main(redishost='redishost', hostname=None, antenna_input=None,
-         integration_time=None):
+         integration_time=None, do_not_initialize=False):
 
     # not actually using the connection
     # but will bw used tempo manipulate the monitoring state
@@ -53,7 +53,14 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
         # Disable the monitoring process for 5 minutes,
         # to stop it interfering with this script
         c.disable_monitoring(300, wait=True)
+
         snap = SnapFengine(SNAP_HOST, redishost=redishost)
+
+        if not snap.is_programmed():
+            snap.fpga.transport.prog_user_image()
+        # maybe add an option to turn of this call?
+        if not do_not_initialize:
+            snap.initialize()
 
         if integration_time is not None:
             acc_len = int(integration_time * 250e6
@@ -182,6 +189,10 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--filename', dest='filename',
                         default='fem_status_plot.html',
                         help='Filename to save the plot.')
+    parser.add_argument('--do_not_initialize', action='store_true',
+                        help="Do not initialize the SNAP(s). "
+                        "This is uncommon and should only be done "
+                        "if observation is currently underway.")
     parser.add_argument('--show', dest='show', action='store_true',
                         help='Show plot.')
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -138,7 +138,8 @@ def make_plot(correlations=None):
                 name = "{state}".format(state=state)
                 autocorr = correlations[host][ant][state]
                 autocorr = 10 * np.log10(np.ma.masked_invalid(autocorr)
-                                         ).filled(-50)
+                                         )
+                autocorr = autocorr.filled(-50)
                 _scatter = go.Scatter(x=freqs,
                                       y=autocorr,
                                       name=name,

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -73,15 +73,16 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
 
         for antenna_ind in ANTENNA_INPUT:
             c.disable_monitoring(60, wait=True)
-
-            fem = snap.fems[antenna_ind]
+            fem_ind = antenna_ind / 2
+            fem_pol = antenna_ind % 2
+            fem = snap.fems[fem_ind]
             current_state = fem.switch()
 
             ant_group = host_group.setdefault(antenna_ind, {})
 
             for state in ['noise', 'load', 'antenna']:
-                fem.switch(state)
-                autocorr = snap.corr.get_new_corr(antenna_ind, antenna_ind)
+                fem.switch(name=state)
+                autocorr = snap.corr.get_new_corr(antenna_ind, antenna_ind).real
 
                 eq_coeff = snap.eq.get_coeffs(antenna_ind)
                 ant_group[state] = autocorr / eq_coeff**2

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -28,6 +28,36 @@ logger = helpers.add_default_log_handlers(logging.getLogger(__name__),
 
 def main(redishost='redishost', hostname=None, antenna_input=None,
          integration_time=None, do_not_initialize=False, no_equalization=False):
+    """Loop through input hostnames and collect spectra for all FEM switch states.
+
+    Parameters
+    ----------
+    redishost : str
+        The name of the redis host to connect to.
+    hostname : str or list of str
+        hostnames to collect spectra from of the form heraNode?Snap?
+        if input is 'all' all snaps in the config file will be used
+    antenna_input : int, list of int, or None
+        Antenna number (ADC Port #) on the snap to collect spectra from.
+        Can accept a single antenna, list, or None.
+        If None all antennas on a snap will be returned with spectra.
+    integration_time : float
+        The desired integration time in s for a spectra.
+    do_not_initialize : bool
+        Flag used to not initialize Snap boards if they are not programmed.
+        This is not a common option and should only be set if observing is underway.
+    no_equalization : bool
+        Do not divide the spectra by the the equalization coefficients
+
+    Returns
+    -------
+    correlations : dict of dict of dict
+        Nested dicts of correlations indexed by keys in the order
+        hostname, antenna index, and load_type
+    snap_to_ant : dict
+        dict defining the snap to antenna mapping for HERA.
+
+    """
     if hostname is None:
         raise ValueError("Must specify a hostname or list of hostames. "
                          "To run on all Snaps set hostame='all'")
@@ -121,6 +151,23 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
 
 
 def make_plot(correlations=None, snap_to_ant=None):
+    """Make a plotly plot from input correlation dict and snap_to_ant dict.
+
+    Parameters
+    ----------
+    correlations : dict of dict of dict
+        Nested dicts of correlations indexed by keys in the order
+        hostname, antenna index, and load_type
+    snap_to_ant : dict (optional)
+        dict defining the snap to antenna mapping for HERA.
+        If no mapping dictionary is provided, plot names will only use ADC Port numbers
+
+    Returns
+    -------
+    plotly figure
+
+
+    """
     n_plots = len(list(correlations.values())[0].keys())
     colors = {"antenna": "blue",
               "load": "orange",

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -60,8 +60,14 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
 
         if not snap.is_programmed():
             snap.fpga.transport.prog_user_image()
-        if not do_not_initialize:
             snap.initialize()
+
+        elif not do_not_initialize:
+            # programmed Snap may sill need to be initialized
+            snap.initialize()
+        else:
+            # Snap is programmed and user does not want to initialize
+            pass
 
         if integration_time is not None:
             acc_len = int(integration_time * 250e6

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -181,10 +181,17 @@ def make_plot(correlations=None, snap_to_ant=None):
     fig = subplots.make_subplots(rows=rows, cols=cols,
                                  subplot_titles=subplot_titles
                                  )
+    gridcolor = 'rgba(0,0,0,.125)'
     for row in range(rows + 1):
         for col in range(cols + 1):
-            fig.update_xaxes(title="Frequency [MHz]", row=row, col=col)
-            fig.update_yaxes(title="Power [dB]", row=row, col=col)
+            fig.update_xaxes(title="Frequency [MHz]", row=row, col=col,
+                             gridcolor=gridcolor,
+                             zerolinecolor=gridcolor
+                             )
+            fig.update_yaxes(title="Power [dB]", row=row, col=col,
+                             gridcolor=gridcolor,
+                             zerolinecolor=gridcolor
+                             )
 
     # lost of nasty plotly code to make stuff
     freqs = np.linspace(0, 250e6, 1024)
@@ -252,7 +259,9 @@ def make_plot(correlations=None, snap_to_ant=None):
     # Finish plot
     layout = go.Layout(showlegend=True,
                        title='Antenna Fem switch states',
-                       updatemenus=[updatemenu]
+                       updatemenus=[updatemenu],
+                       paper_bgcolor='rgba(0,0,0,0)',
+                       plot_bgcolor='rgba(0,0,0,0)',
                        )
     fig.update_layout(layout)
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -143,7 +143,6 @@ def make_plot(correlations=None):
                 _scatter = go.Scatter(x=freqs,
                                       y=autocorr,
                                       name=name,
-                                      host=host,
                                       marker={"color": colors[state],
                                               },
                                       visible=visible,
@@ -159,8 +158,7 @@ def make_plot(correlations=None):
                       for stat in correlations[h2][ant]
                       ]
         _button = {"args": [{"visible": visibility},
-                            {  # "title": '',
-                            "annotations": {}
+                            {"annotations": {}
                              }
                             ],
                    "label": host,

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -54,7 +54,7 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
         # to stop it interfering with this script
         c.disable_monitoring(300, wait=True)
 
-        snap = SnapFengine(SNAP_HOST, redishost=redishost)
+        snap = SnapFengine(host, redishost=redishost)
 
         if not snap.is_programmed():
             snap.fpga.transport.prog_user_image()

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -103,7 +103,7 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
 
 def make_plot(correlations=None):
     n_plots = len(list(correlations.values())[0].keys())
-    colors = {"anteanna": "blue",
+    colors = {"antenna": "blue",
               "load": "orange",
               "noise": "red"
               }
@@ -115,6 +115,10 @@ def make_plot(correlations=None):
     fig = subplots.make_subplots(rows=rows, cols=cols,
                                  subplot_titles=subplot_titles
                                  )
+    for row in range(rows):
+        for col in range(cols):
+            fig.update_xaxes(title="Frequency [MHz]", row=row, col=col)
+            fig.update_yaxes(title="Power [dB]", row=row, col=col)
 
     # lost of nasty plotly code to make stuff
     freqs = np.linspace(0, 250e6, 1024)
@@ -138,7 +142,8 @@ def make_plot(correlations=None):
                 _scatter = go.Scatter(x=freqs,
                                       y=autocorr,
                                       name=name,
-                                      color=colors[state],
+                                      marker={"color": colors[state],
+                                              },
                                       visible=visible,
                                       showlegend=showlegend
                                       )

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -145,6 +145,7 @@ def make_plot(correlations=None):
                                       name=name,
                                       marker={"color": colors[state],
                                               },
+                                      hovertemplate="%{x:.1f}\tMHz<br>%{y:.3f}\t[dB]",
                                       visible=visible,
                                       showlegend=showlegend
                                       )

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -184,7 +184,7 @@ def make_plot(correlations=None, snap_to_ant=None):
             antpol = snap_to_ant[hostnames[0]][int(n)]
             if antpol is None:
                 antpol = 'N/C'
-            subplot_titles.append('ADC PORT {port} {antpol}'
+            subplot_titles.append('ADC PORT {port}<br>{antpol}'
                                   .format(port=n, antpol=antpol)
                                   )
         else:
@@ -249,8 +249,8 @@ def make_plot(correlations=None, snap_to_ant=None):
                 antpol = snap_to_ant[host][int(port)]
                 if antpol is None:
                     antpol = 'N/C'
-                _an.text = 'ADC PORT {port} {antpol}'.format(port=port,
-                                                             antpol=antpol)
+                _an.text = 'ADC PORT {port}<br>{antpol}'.format(port=port,
+                                                                antpol=antpol)
             else:
                 _an.text = 'ADC PORT {port}'.format(port=port)
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -58,7 +58,6 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
 
         if not snap.is_programmed():
             snap.fpga.transport.prog_user_image()
-        # maybe add an option to turn of this call?
         if not do_not_initialize:
             snap.initialize()
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -121,11 +121,9 @@ def make_plot(correlations=None):
                 _scatter = go.Scatter(x=freqs,
                                       y=autocorr,
                                       name=name,
-                                      row=row,
-                                      col=col,
                                       visible=visible)
                 scatters.append(_scatter)
-                fig.add_trace(_scatter)
+                fig.add_trace(_scatter, row=row, col=col)
 
     # make a mask for each host
     host_mask = []
@@ -136,6 +134,7 @@ def make_plot(correlations=None):
                           for ant in correlations[h2]
                           for state in correlations[h2][ant]
                           ])
+        host_mask.append(_mask)
 
     buttons = []
     for host_cnt, host in enumerate(hostnames):

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -25,7 +25,9 @@ logger = helpers.add_default_log_handlers(logging.getLogger(__name__),
 
 def main(redishost='redishost', hostname=None, antenna_input=None,
          integration_time=None, do_not_initialize=False):
-
+    if hostname is None:
+        raise ValueError("Must specify a hostname or list of hostames. "
+                         "To run on all Snaps set hostame='all'")
     # not actually using the connection
     # but will bw used tempo manipulate the monitoring state
     # and find all hosts if needed.
@@ -37,11 +39,11 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
 
     hostname = sorted(hostname)
 
-    if not hostname and not antenna_input:
+    if hostname == ['all'] and not antenna_input:
         logger.info("Using all SNAPs from redis configuration")
         SNAP_HOST = sorted(list(c.config['fengines'].keys()))
         ANTENNA_INPUT = np.arange(0, 6)
-    elif hostname and not antenna_input:
+    elif hostname != ['all'] and not antenna_input:
         SNAP_HOST = hostname
         ANTENNA_INPUT = np.arange(0, 6)
     else:
@@ -188,14 +190,16 @@ if __name__ == "__main__":
             'Record a auto-correlation spectra from the SNAP for each state. '
             'Can run on a single antenna when both "hostname" and "antenna_input" '
             'are set. If "hostname" is set with no "ANTENNA_INPUT" will run on all '
-            'antennas in that SNAP. If both inputs "hostname" '
-            'and "antenna_input" are not provides, will loop through all SNAPS '
-            'and all antennas.')
+            'antennas in that SNAP. To run on all Snaps and antennas set '
+            '"hostname" to all.')
     parser = argparse.ArgumentParser(description=desc,
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    parser.add_argument(dest='hostname', type=str, nargs='*',
-                        help='Host board to collect data from.')
+    parser.add_argument(dest='hostname', type=str, nargs='+',
+                        help=('Host board to collect data from. '
+                              'Formatted as heraNode?Snap? or '
+                              '"all" for all Snaps.')
+                        )
     parser.add_argument('-r', dest='redishost', type=str, default='redishost',
                         help='Host servicing redis requests')
     parser.add_argument('-a', '--antenna_input', dest='antenna_input',

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -115,8 +115,8 @@ def make_plot(correlations=None):
     fig = subplots.make_subplots(rows=rows, cols=cols,
                                  subplot_titles=subplot_titles
                                  )
-    for row in range(rows):
-        for col in range(cols):
+    for row in range(rows + 1):
+        for col in range(cols + 1):
             fig.update_xaxes(title="Frequency [MHz]", row=row, col=col)
             fig.update_yaxes(title="Power [dB]", row=row, col=col)
 

--- a/control_software/scripts/hera_fem_switch_loop.py
+++ b/control_software/scripts/hera_fem_switch_loop.py
@@ -35,7 +35,7 @@ def main(redishost='redishost', hostname=None, antenna_input=None,
         if not isinstance(hostname, (list, tuple)):
             hostname = [hostname]
 
-        hostname = sorted(hostname)
+    hostname = sorted(hostname)
 
     if not hostname and not antenna_input:
         logger.info("Using all SNAPs from redis configuration")


### PR DESCRIPTION
adds a script to loop through FEM states and record spectra for a given set of input Snaps and antenna.

current output is like example at http://heranow.reionization.org/fem_status_plot.html.

Scales to ~4s per adc port. Allows user to specify any number of hostnames as input or 'all' to loop over all Snaps