### PR TITLE
Accommodate for redis bug

### DIFF
--- a/control_software/src/hera_corr.py
+++ b/control_software/src/hera_corr.py
@@ -810,7 +810,7 @@ class HeraCorrelator(object):
         for xn, xparams in self.config['xengines'].items():
             chan_range = xparams.get('chan_range', [xn*384, (xn+1)*384])
             chans = range(chan_range[0], chan_range[1])
-            self.r.hset("corr:xeng_chans", xn, json.dumps(chans))
+            self.r.hset("corr:xeng_chans", str(xn), json.dumps(chans))
             if (xn > n_xengs):
                 self.logger.error("Cannot have more than %d X-engs!!" % n_xengs)
                 return False


### PR DESCRIPTION
update an hset key to str to conform with newer redis version.

redis-py version 3.5.0 has a bug where hset argument 2 must be a string and is not automatically cast as a string. This update allows hera_corr_f to function properly with this version of redis-py