### PR TITLE
Make redis values redis-accepted types

### DIFF
--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -321,6 +321,11 @@ if __name__ == "__main__":
                 except:  # noqa
                     snap_rf_stats['eq_coeffs'] = None
                 snap_rf_stats['timestamp'] = datetime.datetime.now().isoformat()
+
+                for key in snap_rf_stats:
+                    if snap_rf_stats[key] is None:
+                        snap_rf_stats[key] = json.dumps(snap_rf_stats[key])
+
                 corr.r.hmset(status_key, snap_rf_stats)
 
         for key, val in input_stats.iteritems():
@@ -332,9 +337,9 @@ if __name__ == "__main__":
                     continue
                 ant, pol = redis_cm.hera_antpol_to_ant_pol(antpol)
                 status_key = 'status:ant:%s:%s' % (ant, pol)
-                mean  = means[antn]
+                mean = means[antn]
                 power = powers[antn]
-                rms   = rmss[antn]
+                rms = rmss[antn]
                 redis_vals = {'adc_mean': mean, 'adc_power': power, 'adc_rms': rms}
                 # Give the antenna hash a key indicating the SNAP and input number it is associated with
                 redis_vals['f_host'] = key

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -378,6 +378,9 @@ if __name__ == "__main__":
                         # values that are appearing as lists as loaded
                         # with json.loads in corr_cm
                         redis_vals[key] = json.dumps(redis_vals[key])
+                    elif redis_vals[key] is None:
+                        # newer redis-py does not accept Nonetype, wrap in json.dumps
+                        redis_vals[key] = json.dumps(redis_vals[key])
 
                 corr.r.hmset(status_key, redis_vals)
 

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -368,11 +368,17 @@ if __name__ == "__main__":
                 except KeyError:
                     pass
 
+                redis_vals['timestamp'] = datetime.datetime.now().isoformat()
+
                 for key in redis_vals:
                     if isinstance(redis_vals[key], bool):
+                        # bools are compared using lambda x: x == "True" later
                         redis_vals[key] = str(redis_vals[key])
+                    elif isinstance(redis_vals[key], list):
+                        # values that are appearing as lists as loaded
+                        # with json.loads in corr_cm
+                        redis_vals[key] = json.dumps(redis_vals[key])
 
-                redis_vals['timestamp'] = datetime.datetime.now().isoformat()
                 corr.r.hmset(status_key, redis_vals)
 
         # Get FPGA stats

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -376,6 +376,8 @@ if __name__ == "__main__":
                 redis_vals['timestamp'] = datetime.datetime.now().isoformat()
 
                 for key in redis_vals:
+                    # make a few explicit type conversions to coerce non-redis
+                    # compatible variables into redis.
                     if isinstance(redis_vals[key], bool):
                         # bools are compared using lambda x: x == "True" later
                         redis_vals[key] = str(redis_vals[key])

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -367,6 +367,11 @@ if __name__ == "__main__":
                     redis_vals["fft_of"] = fft_of[key]
                 except KeyError:
                     pass
+
+                for key in redis_vals:
+                    if isinstance(redis_vals[key], bool):
+                        redis_vals[key] = str(redis_vals[key])
+
                 redis_vals['timestamp'] = datetime.datetime.now().isoformat()
                 corr.r.hmset(status_key, redis_vals)
 


### PR DESCRIPTION
Newer redis verisons are much stricter on types that are allowed to be put into the database. I have found some list, bool, and Nonetype entries trying to sneak in in `hera_snap_redis_monitor.py` and have tried to add a block to be robust against these types. 

Current check looks like things get plumbed through enough on the `corr_cm` side. I tried to not change anything in a way that would make `corr_cm` unhappy.

Still maybe need a full testing run, but have received some data.

![image](https://user-images.githubusercontent.com/8646829/85775672-d6208980-b6d4-11ea-947b-498f938427f3.png)
