### PR TITLE
Sync issues

### DIFF
--- a/control_software/config/hera_feng_config.yaml
+++ b/control_software/config/hera_feng_config.yaml
@@ -43,12 +43,11 @@ eth: False
 
 # FFT shift. One bit per FFT stage, the first stage is the LSB
 # If the FFT uses bit growth, some or all of the stages may be ignored
-fft_shift: 0b0001010101000000
+fft_shift: 0x0fff 
 
 # Specify a full path to an F-Engine fpg files
 # or redis:<fpg filename> if the fpg file has been uploaded to redis
-fpgfile: 'redis:snap_fengine_2020-06-15_1438.fpg'
-#fpgfile: 'redis:snap_fengine_2019-08-29_1717.fpg'
+fpgfile: 'redis:snap_fengine_2020-07-16_1253.fpg'
 
 # Destination port for SNAP data
 dest_port: 8511

--- a/control_software/scripts/hera_snap_feng_init.py
+++ b/control_software/scripts/hera_snap_feng_init.py
@@ -95,13 +95,8 @@ def main():
         # assigning slots- 16 for the even bank, 16 for the odd.
         # Channels not assigned to Xengs in the config file are
         # ignored. Following are the assumed globals:
-        if not corr.configure_freq_slots():
-            logger.info('Configuring frequency slots failed with multithreading.')
-            logger.info('Attempting without multithreading')
-            if corr.configure_freq_slots(multithread=False):
-               logger.info('Done setting frequency slots.')
-            else:
-               logger.error('Configuring frequency slots failed!')
+        if not corr.configure_freq_slots(multithread=False):
+            logger.info('Configuring frequency slots failed!')
 
     if args.tvg:
         logger.info('Enabling EQ TVGs...')

--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -434,10 +434,8 @@ class Input(Block):
             stream (int): Which stream to switch. If None, switch all.
         """
         if stream is None:
-            v = 0
             for stream in range(self.ninput_mux_streams):
-                v += self.USE_NOISE << (2 * stream)
-            self.write_int('source_sel', v)
+                self.change_reg_bits('source_sel', self.USE_NOISE, 2*(self.ninput_mux_streams-1-stream), 2)
         else:
             self.change_reg_bits('source_sel', self.USE_NOISE, 2*(self.ninput_mux_streams-1-stream), 2)
 
@@ -448,10 +446,8 @@ class Input(Block):
             stream (int): Which stream to switch. If None, switch all.
         """
         if stream is None:
-            v = 0
             for stream in range(self.ninput_mux_streams):
-                v += self.USE_ADC << (2 * stream)
-            self.write_int('source_sel', v)
+                self.change_reg_bits('source_sel', self.USE_ADC, 2*(self.ninput_mux_streams-1-stream), 2)
         else:
             self.change_reg_bits('source_sel', self.USE_ADC, 2*(self.ninput_mux_streams-1-stream), 2)
 
@@ -462,10 +458,8 @@ class Input(Block):
             stream (int): Which stream to switch. If None, switch all.
         """
         if stream is None:
-            v = 0
             for stream in range(self.ninput_mux_streams):
-                v += self.USE_ZERO << (2 * stream)
-            self.write_int('source_sel', v)
+                self.change_reg_bits('source_sel', self.USE_ZERO, 2*(self.ninput_mux_streams-1-stream), 2)
         else:
             self.change_reg_bits('source_sel', self.USE_ZERO, 2*(self.ninput_mux_streams-1-stream), 2)
 
@@ -497,7 +491,7 @@ class Input(Block):
         Switch to ADCs. Begin computing stats.
          """
         self.use_adc()
-        self.write_int('rms_enable', 1)
+        #self.write_int('rms_enable', 1)
 
     def print_status(self):
         mean, power, rms = self.get_stats()

--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -491,6 +491,8 @@ class Input(Block):
         Switch to ADCs. Begin computing stats.
          """
         self.use_adc()
+
+        #rms code removed from current version of fpga software
         #self.write_int('rms_enable', 1)
 
     def print_status(self):
@@ -1348,7 +1350,7 @@ class RoachInput(Block):
 
     def initialize(self):
         self.use_adc()
-        self.write_int('rms_enable', 1)
+        #self.write_int('rms_enable', 1)
 
     def print_status(self):
         print self.get_stats()


### PR DESCRIPTION
Fixed some node sync issues.

1. Track the SNAPs that successfully configured their ADCs and were able to initialize correctly.
2. Separately track the SNAPs that failed ADC calibration- these SNAPs are not prevented from sending data.
3. Steal bits from the 'source_sel' register to keep track of these properties- they were previously being "tracked" using class instance variables that got reset every time a new instance was created. This lead to SNAPs that failed ADC configuration being considered as good SNAPs sometimes.

**To Fix**: SNAPs that failed ADC calibration should not be initialized. However, there are some SNAPs that report not-ADC-configured but initialized. Unable to debug why this would happen. But these SNAPs do not transmit data, so this bug is not causing a real issue. 