### PR TITLE
Re-enable ADC monitoring

### DIFF
--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -279,7 +279,8 @@ if __name__ == "__main__":
         # input_stats = corr.do_for_all_f("get_stats", block="input", kwargs={"sum_cores": True})
         input_stats = {}
         histograms = {}
-        bins = np.arange(-128, 128)
+        bins = np.arange(-128, 129)
+        bin_centers = (bins[1:] + bins[:1]) / 2
         for feng in corr.fengs:
             histograms[feng.host] = []
             input_stats[feng.host] = []
@@ -288,8 +289,8 @@ if __name__ == "__main__":
                     x, y = feng.input.get_adc_snapshot(i)
                     hist_x, _ = np.histogram(x, bins=bins)
                     hist_y, _ = np.histogram(x, bins=bins)
-                    histograms[feng.host].append([bins, hist_x])
-                    histograms[feng.host].append([bins, hist_y])
+                    histograms[feng.host].append([bin_centers, hist_x])
+                    histograms[feng.host].append([bin_centers, hist_y])
                     input_stats[feng.host].append(
                         [
                             x.mean(), np.mean(x**2), np.sqrt(np.mean(x**2))

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
         # input_stats = corr.do_for_all_f("get_stats", block="input", kwargs={"sum_cores": True})
         input_stats = {}
         histograms = {}
-        bins = np.arange(-128, 129)
+        bins = np.arange(-128, 128)
         for feng in corr.fengs:
             histograms[feng.host] = []
             input_stats[feng.host] = []
@@ -288,8 +288,8 @@ if __name__ == "__main__":
                     x, y = feng.input.get_adc_snapshot(i)
                     hist_x, _ = np.histogram(x, bins=bins)
                     hist_y, _ = np.histogram(x, bins=bins)
-                    histograms[feng.host].append([bins, hist_x])
-                    histograms[feng.host].append([bins, hist_y])
+                    histograms[feng.host].append([bins.tolist(), hist_x.tolist()])
+                    histograms[feng.host].append([bins.tolist(), hist_y.tolist()])
                     input_stats[feng.host].append(
                         [
                             x.mean(), np.mean(x**2), np.sqrt(np.mean(x**2))
@@ -305,8 +305,8 @@ if __name__ == "__main__":
                         "Connection issue on snap {} ant {};"
                         "skipping adc data acquistion.".format(feng.host, i)
                     )
-                    histograms[feng.host].append([None, None])
-                    histograms[feng.host].append([None, None])
+                    histograms[feng.host].append([[None], [None]])
+                    histograms[feng.host].append([[None], [None]])
                     input_stats[feng.host].append(
                         [None, None, None]
                     )

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -275,7 +275,9 @@ if __name__ == "__main__":
         corr.r.hmset('version:%s:%s' % (__package__, os.path.basename(__file__)), {'version':__version__, 'timestamp':datetime.datetime.now().isoformat()})
 
         # Get antenna stats
-        # do_for_all_f breaking on adc stats, casting to None 25 Aug 2020
+        # 25 AUG 2020 do_for_all_f breaking on adc stats
+        # recent bitfile change has removed some blocks on the snap.
+        # must use adc snapshot now and build statistics in software instead.
         # input_stats = corr.do_for_all_f("get_stats", block="input", kwargs={"sum_cores": True})
         input_stats = {}
         histograms = {}

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
         # input_stats = corr.do_for_all_f("get_stats", block="input", kwargs={"sum_cores": True})
         input_stats = {}
         histograms = {}
-        bins = np.arange(-128, 129)
+        bins = np.arange(-128, 128)
         bin_centers = (bins[1:] + bins[:1]) / 2
         for feng in corr.fengs:
             histograms[feng.host] = []
@@ -288,7 +288,7 @@ if __name__ == "__main__":
                 try:
                     x, y = feng.input.get_adc_snapshot(i)
                     hist_x, _ = np.histogram(x, bins=bins)
-                    hist_y, _ = np.histogram(x, bins=bins)
+                    hist_y, _ = np.histogram(y, bins=bins)
                     histograms[feng.host].append([bin_centers, hist_x])
                     histograms[feng.host].append([bin_centers, hist_y])
                     input_stats[feng.host].append(

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -302,8 +302,8 @@ if __name__ == "__main__":
                     )
                 except:  # noqa
                     logger.info(
-                        "Connection issue on snap {}, "
-                        "skipping adc data acquistion.".format(feng.host)
+                        "Connection issue on snap {} ant {}"
+                        "skipping adc data acquistion.".format(feng.host, i)
                     )
                     histograms[feng.host].append([None, None])
                     histograms[feng.host].append([None, None])
@@ -369,7 +369,7 @@ if __name__ == "__main__":
 
                 corr.r.hmset(status_key, snap_rf_stats)
 
-        for key, val in fft_of.iteritems():
+        for key in input_stats:
             antpols = corr.fengs_by_name[key].ants
 
             for antn, antpol in enumerate(antpols):

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -275,7 +275,9 @@ if __name__ == "__main__":
         corr.r.hmset('version:%s:%s' % (__package__, os.path.basename(__file__)), {'version':__version__, 'timestamp':datetime.datetime.now().isoformat()})
 
         # Get antenna stats
-        input_stats = corr.do_for_all_f("get_stats", block="input", kwargs={"sum_cores": True})
+        # do_for_all_f breaking on adc stats, casting to None 25 Aug 2020
+        # input_stats = corr.do_for_all_f("get_stats", block="input", kwargs={"sum_cores": True})
+        input_stats = {}
         if corr.r.exists('disable_monitoring'):
             continue
         histograms = []
@@ -328,19 +330,21 @@ if __name__ == "__main__":
 
                 corr.r.hmset(status_key, snap_rf_stats)
 
-        for key, val in input_stats.iteritems():
+        for key, val in fft_of.iteritems():
             antpols = corr.fengs_by_name[key].ants
-            means, powers, rmss = val
+            # means, powers, rmss = val
             for antn, antpol in enumerate(antpols):
                 # Don't report inputs which aren't connected
                 if antpol is None:
                     continue
                 ant, pol = redis_cm.hera_antpol_to_ant_pol(antpol)
                 status_key = 'status:ant:%s:%s' % (ant, pol)
-                mean = means[antn]
-                power = powers[antn]
-                rms = rmss[antn]
-                redis_vals = {'adc_mean': mean, 'adc_power': power, 'adc_rms': rms}
+                # do_for_all_f breaking on adc stats, casting to None 25 Aug 2020
+                # mean = means[antn]
+                # power = powers[antn]
+                # rms = rmss[antn]
+                # redis_vals = {'adc_mean': mean, 'adc_power': power, 'adc_rms': rms}
+                redis_vals = {'adc_mean': None, 'adc_power': None, 'adc_rms': None}
                 # Give the antenna hash a key indicating the SNAP and input number it is associated with
                 redis_vals['f_host'] = key
                 redis_vals['host_ant_id'] = antn

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -367,7 +367,7 @@ if __name__ == "__main__":
                         snap_rf_stats[snap_key] = json.dumps(snap_rf_stats[snap_key])
 
                 corr.r.hmset(status_key, snap_rf_stats)
-        print(list(input_stats.keys()))
+
         for host in input_stats:
             antpols = corr.fengs_by_name[host].ants
 

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -288,8 +288,8 @@ if __name__ == "__main__":
                     x, y = feng.input.get_adc_snapshot(i)
                     hist_x, _ = np.histogram(x, bins=bins)
                     hist_y, _ = np.histogram(x, bins=bins)
-                    histograms[feng.host].append([bins.tolist(), hist_x.tolist()])
-                    histograms[feng.host].append([bins.tolist(), hist_y.tolist()])
+                    histograms[feng.host].append([bins, hist_x])
+                    histograms[feng.host].append([bins, hist_y])
                     input_stats[feng.host].append(
                         [
                             x.mean(), np.mean(x**2), np.sqrt(np.mean(x**2))

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         for i in range(6):
             if corr.r.exists('disable_monitoring'):
                 continue
-            histograms += [corr.do_for_all_f("get_input_histogram", block="input", args=(i,))]
+            # histograms += [corr.do_for_all_f("get_input_histogram", block="input", args=(i,))]
             eq_coeffs += [corr.do_for_all_f("get_coeffs", block="eq", args=(i,))]
             autocorrs += [corr.do_for_all_f("get_new_corr", block="corr", args=(i, i))]
         # We only detect overflow once per FPGA (not per antenna).
@@ -302,7 +302,7 @@ if __name__ == "__main__":
 
         # Write spectra to snap-indexed keys. This means we'll get spectra even from
         # unconnected (according to the CM database) antennas
-        for snap in histograms[0].keys():
+        for snap in autocorrs[0].keys():
             for antn in range(6):
                 status_key = 'status:snaprf:%s:%d' % (snap, antn)
                 snap_rf_stats = {}

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -302,7 +302,7 @@ if __name__ == "__main__":
                     )
                 except:  # noqa
                     logger.info(
-                        "Connection issue on snap {} ant {}"
+                        "Connection issue on snap {} ant {};"
                         "skipping adc data acquistion.".format(feng.host, i)
                     )
                     histograms[feng.host].append([None, None])
@@ -325,7 +325,6 @@ if __name__ == "__main__":
         for i in range(6):
             if corr.r.exists('disable_monitoring'):
                 continue
-            # histograms += [corr.do_for_all_f("get_input_histogram", block="input", args=(i,))]
             eq_coeffs += [corr.do_for_all_f("get_coeffs", block="eq", args=(i,))]
             autocorrs += [corr.do_for_all_f("get_new_corr", block="corr", args=(i, i))]
         # We only detect overflow once per FPGA (not per antenna).
@@ -363,14 +362,14 @@ if __name__ == "__main__":
                     snap_rf_stats['eq_coeffs'] = None
                 snap_rf_stats['timestamp'] = datetime.datetime.now().isoformat()
 
-                for key in snap_rf_stats:
-                    if snap_rf_stats[key] is None:
-                        snap_rf_stats[key] = json.dumps(snap_rf_stats[key])
+                for snap_key in snap_rf_stats:
+                    if snap_rf_stats[snap_key] is None:
+                        snap_rf_stats[snap_key] = json.dumps(snap_rf_stats[snap_key])
 
                 corr.r.hmset(status_key, snap_rf_stats)
-
-        for key in input_stats:
-            antpols = corr.fengs_by_name[key].ants
+        print(list(input_stats.keys()))
+        for host in input_stats:
+            antpols = corr.fengs_by_name[host].ants
 
             for antn, antpol in enumerate(antpols):
                 # Don't report inputs which aren't connected
@@ -379,24 +378,23 @@ if __name__ == "__main__":
                 ant, pol = redis_cm.hera_antpol_to_ant_pol(antpol)
                 status_key = 'status:ant:%s:%s' % (ant, pol)
 
-                mean, power, rms = input_stats[key][antn]
+                mean, power, rms = input_stats[host][antn]
 
                 redis_vals = {'adc_mean': mean, 'adc_power': power, 'adc_rms': rms}
-                # redis_vals = {'adc_mean': None, 'adc_power': None, 'adc_rms': None}
                 # Give the antenna hash a key indicating the SNAP and input number it is associated with
-                redis_vals['f_host'] = key
+                redis_vals['f_host'] = host
                 redis_vals['host_ant_id'] = antn
                 try:
-                    hist_bins, hist_vals = histograms[key][antn]
+                    hist_bins, hist_vals = histograms[host][antn]
                     redis_vals['histogram'] = json.dumps([hist_bins.tolist(), hist_vals.tolist()])
                 except:  # noqa
                     redis_vals['histogram'] = None
                 try:
-                    redis_vals['autocorrelation'] = json.dumps(autocorrs[antn][key].real.tolist())
+                    redis_vals['autocorrelation'] = json.dumps(autocorrs[antn][host].real.tolist())
                 except:  # noqa
                     redis_vals['autocorrelation'] = None
                 try:
-                    coeffs = eq_coeffs[antn][key]
+                    coeffs = eq_coeffs[antn][host]
                     redis_vals['eq_coeffs'] = json.dumps(coeffs.tolist())
                 except:
                     redis_vals['eq_coeffs'] = None
@@ -411,25 +409,25 @@ if __name__ == "__main__":
                 except KeyError:
                     pass
                 try:
-                    redis_vals["fft_of"] = fft_of[key]
+                    redis_vals["fft_of"] = fft_of[host]
                 except KeyError:
                     pass
 
                 redis_vals['timestamp'] = datetime.datetime.now().isoformat()
 
-                for key in redis_vals:
+                for redis_key in redis_vals:
                     # make a few explicit type conversions to coerce non-redis
                     # compatible variables into redis.
-                    if isinstance(redis_vals[key], bool):
+                    if isinstance(redis_vals[redis_key], bool):
                         # bools are compared using lambda x: x == "True" later
-                        redis_vals[key] = str(redis_vals[key])
-                    elif isinstance(redis_vals[key], list):
+                        redis_vals[redis_key] = str(redis_vals[redis_key])
+                    elif isinstance(redis_vals[redis_key], list):
                         # values that are appearing as lists as loaded
                         # with json.loads in corr_cm
-                        redis_vals[key] = json.dumps(redis_vals[key])
-                    elif redis_vals[key] is None:
+                        redis_vals[redis_key] = json.dumps(redis_vals[redis_key])
+                    elif redis_vals[redis_key] is None:
                         # newer redis-py does not accept Nonetype, wrap in json.dumps
-                        redis_vals[key] = json.dumps(redis_vals[key])
+                        redis_vals[redis_key] = json.dumps(redis_vals[redis_key])
 
                 corr.r.hmset(status_key, redis_vals)
 

--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -303,8 +303,10 @@ if __name__ == "__main__":
                     )
                 except:  # noqa
                     logger.info(
-                        "Connection issue on snap {} ant {};"
-                        "skipping adc data acquistion.".format(feng.host, i)
+                        "Connection issue on snap {} ant {}; "
+                        "skipping adc data acquistion."
+                        "Full error output:".format(feng.host, i),
+                        exc_info=True,
                     )
                     histograms[feng.host].append([[None], [None]])
                     histograms[feng.host].append([[None], [None]])
@@ -351,15 +353,33 @@ if __name__ == "__main__":
                     hist_bins, hist_vals = histograms[snap][antn]
                     snap_rf_stats['histogram'] = json.dumps([hist_bins.tolist(), hist_vals.tolist()])
                 except:  # noqa
+                    logger.info(
+                        "Exception encountered filling snaprf_stats histogram "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     snap_rf_stats['histogram'] = None
                 try:
                     snap_rf_stats['autocorrelation'] = json.dumps(autocorrs[antn][snap].real.tolist())
                 except:  # noqa
+                    logger.info(
+                        "Exception encountered filling snaprf_stats autocorrelation "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     snap_rf_stats['autocorrelation'] = None
                 try:
                     coeffs = eq_coeffs[antn][snap]
                     snap_rf_stats['eq_coeffs'] = json.dumps(coeffs.tolist())
                 except:  # noqa
+                    logger.info(
+                        "Exception encountered filling snaprf_stats eq_coeffs "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     snap_rf_stats['eq_coeffs'] = None
                 snap_rf_stats['timestamp'] = datetime.datetime.now().isoformat()
 
@@ -389,29 +409,65 @@ if __name__ == "__main__":
                     hist_bins, hist_vals = histograms[host][antn]
                     redis_vals['histogram'] = json.dumps([hist_bins.tolist(), hist_vals.tolist()])
                 except:  # noqa
+                    logger.info(
+                        "Exception encountered filling antenna_status histogram "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     redis_vals['histogram'] = None
                 try:
                     redis_vals['autocorrelation'] = json.dumps(autocorrs[antn][host].real.tolist())
                 except:  # noqa
+                    logger.info(
+                        "Exception encountered filling antenna_status autocorrelation "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     redis_vals['autocorrelation'] = None
                 try:
                     coeffs = eq_coeffs[antn][host]
                     redis_vals['eq_coeffs'] = json.dumps(coeffs.tolist())
                 except:
+                    logger.info(
+                        "Exception encountered filling antenna_status autocorrelation "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     redis_vals['eq_coeffs'] = None
                 try:
                     redis_vals.update(pam_stats[ant][pol])
                 except KeyError:
+                    logger.info(
+                        "Exception encountered filling antenna_status pam statistics "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     # if a SNAP died between getting input stats (which is the dictionary we are looping over)
                     # and getting pam/fem stats, the appropriate PAM/FEM keys may not exist
                     pass
                 try:
                     redis_vals.update(fem_stats[ant][pol])
                 except KeyError:
+                    logger.info(
+                        "Exception encountered filling antenna_status fem statistics "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     pass
                 try:
                     redis_vals["fft_of"] = fft_of[host]
                 except KeyError:
+                    logger.info(
+                        "Exception encountered filling antenna_status fft_of "
+                        "for snap {} antenna index {}; Setting to None."
+                        "Full traceback attached.".format(snap, antn),
+                        exc_info=True,
+                    )
                     pass
 
                 redis_vals['timestamp'] = datetime.datetime.now().isoformat()


### PR DESCRIPTION
The new bitfile removed some blocks used in the `hera_snap_redis_monitor`. This re-enables the adc monitoring functionality by getting adc snapshots from each snap instead of calling the missing blocks.

It also fixes an issue in some for loop iteration variable degeneracies. Multiple nested for loops used the variable `key` before.