### PR TITLE
Get fft shift

### DIFF
--- a/control_software/scripts/hera_snap_feng_init.py
+++ b/control_software/scripts/hera_snap_feng_init.py
@@ -45,13 +45,17 @@ def main():
                              'irrespective of whether they are programmed already')
     parser.add_argument('--multithread', action='store_true', default=False,
                         help='Multithread initialization (not recommended for a high number of SNAPs)')
+    parser.add_argument('--allsnaps', action='store_true', default=False,
+                        help='Require communication with all snaps (exit if any are put in dead_fengs")')
     args = parser.parse_args()
 
     logger = handlers.add_default_log_handlers(logging.getLogger(__file__))
     handlers.log_notify(logger)  # send a NOTIFY level message that this script has started
 
     corr = HeraCorrelator(redishost=args.redishost, config=args.config_file, use_redis=False)  # noqa
-
+    if args.allsnaps and len(corr.dead_fengs) != 0:
+        logger.error("Requiring all SNAPS, but %d were dead." % len(corr.dead_fengs))
+        exit()
     if (len(corr.fengs) == 0) and (len(corr.uninit_fengs) == 0):
         logger.error("No F-Engines are connected. Is the power off?")
         exit()

--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -643,7 +643,9 @@ class Pfb(Block):
         """
         Return the current FFT shift schedule (LSB = stage 1, MSB = stage N).
         """
-        return self.read_uint('ctrl', self.SHIFT_OFFSET)
+        shift = self.read_uint('ctrl', self.SHIFT_OFFSET)
+        shift &= 0xffff # return only the bottom 16-bits of the 32b register
+        return shift
 
     def set_fft_shift(self, shift):
         """

--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -639,8 +639,19 @@ class Pfb(Block):
         self.PRESHIFT_WIDTH  = 2
         self.STAT_RST_BIT = 18
 
+    def get_fft_shift(self):
+        """
+        Return the current FFT shift schedule (LSB = stage 1, MSB = stage N).
+        """
+        return self.read_uint('ctrl', self.SHIFT_OFFSET)
+
     def set_fft_shift(self, shift):
+        """
+        Set the FFT shift schedule to the specified unsigned integer
+        (LSB = stage 1, MSB = stage N).
+        """
         self.change_reg_bits('ctrl', shift, self.SHIFT_OFFSET, self.SHIFT_WIDTH)
+        assert(self.get_fft_shift() == shift) # ensure write was successful
 
     def set_fft_preshift(self, shift):
         self.change_reg_bits('ctrl', shift, self.PRESHIFT_OFFSET, self.PRESHIFT_WIDTH)

--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -651,7 +651,6 @@ class Pfb(Block):
         (LSB = stage 1, MSB = stage N).
         """
         self.change_reg_bits('ctrl', shift, self.SHIFT_OFFSET, self.SHIFT_WIDTH)
-        assert(self.get_fft_shift() == shift) # ensure write was successful
 
     def set_fft_preshift(self, shift):
         self.change_reg_bits('ctrl', shift, self.PRESHIFT_OFFSET, self.PRESHIFT_WIDTH)


### PR DESCRIPTION
Added capability to read the fft_shift of a pfb block in an f engine, and added a flag to hera_snap_feng_init.py to require all snaps to be present (not dead) before proceeding. All changes should be backward compatible.