### PR TITLE
Update histogram failures to use arrays

### DIFF
--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -310,8 +310,8 @@ if __name__ == "__main__":
                         "Full error output:".format(feng.host, i),
                         exc_info=True,
                     )
-                    histograms[feng.host].append([[None], [None]])
-                    histograms[feng.host].append([[None], [None]])
+                    histograms[feng.host].append([np.array([None]), np.array([None])])
+                    histograms[feng.host].append([np.array([None]), np.array([None])])
                     input_stats[feng.host].append(
                         [None, None, None]
                     )


### PR DESCRIPTION
Updates the caught exception in hera_snap_redis_monitor to insert arrays of None instead of lists. Later in the script when these values are packed into a json string a `tolist` is called. 

This preserves that tolist, though we could move the tolist call up into the try statement at line 290 as well.

closes #29 