### PR TITLE
Survive feng adc

### DIFF
--- a/control_software/scripts/hera_feng_start.sh
+++ b/control_software/scripts/hera_feng_start.sh
@@ -7,9 +7,9 @@ set -e
 
 echo hera_start_feng.sh: Initializing F-Engines > $LOGFILE
 date >> $LOGFILE
-hera_snap_feng_init.py -p -i -d &> $LOGFILE
+hera_snap_feng_init.py -p -i -d &>> $LOGFILE
 
 echo >> $LOGFILE
 echo >> $LOGFILE
 echo hera_start_feng.sh: Synchronizing and Starting TX
-hera_snap_feng_init.py -s -e &> $LOGFILE
+hera_snap_feng_init.py -s -e &>> $LOGFILE

--- a/control_software/scripts/hera_feng_start.sh
+++ b/control_software/scripts/hera_feng_start.sh
@@ -5,11 +5,11 @@ LOGFILE=~/snap_start.log
 source ~/.bashrc
 set -e
 
-echo hera_start_feng.sh: Initializing F-Engines > $LOGFILE
+echo hera_feng_start.sh: Initializing F-Engines > $LOGFILE
 date >> $LOGFILE
 hera_snap_feng_init.py -p -i -d &>> $LOGFILE
 
 echo >> $LOGFILE
 echo >> $LOGFILE
-echo hera_start_feng.sh: Synchronizing and Starting TX
+echo hera_feng_start.sh: Synchronizing and Starting TX
 hera_snap_feng_init.py -s -e &>> $LOGFILE

--- a/control_software/scripts/hera_feng_start.sh
+++ b/control_software/scripts/hera_feng_start.sh
@@ -1,17 +1,15 @@
 #! /bin/bash
 
 LOGFILE=~/snap_start.log
-ERRFILE=~/snap_start.err
 
 source ~/.bashrc
 set -e
 
 echo hera_start_feng.sh: Initializing F-Engines > $LOGFILE
-hera_snap_feng_init.py -p -i -d >> $LOGFILE 2> $ERRFILE
+date >> $LOGFILE
+hera_snap_feng_init.py -p -i -d &> $LOGFILE
 
 echo >> $LOGFILE
 echo >> $LOGFILE
-echo >> $ERRFILE
-echo >> $ERRFILE
 echo hera_start_feng.sh: Synchronizing and Starting TX
-hera_snap_feng_init.py -s -e >> $LOGFILE 2>> $ERRFILE
+hera_snap_feng_init.py -s -e &> $LOGFILE

--- a/control_software/src/hera_corr.py
+++ b/control_software/src/hera_corr.py
@@ -793,11 +793,12 @@ class HeraCorrelator(object):
         self.logger.info('Synchronizing F-Engines')
         if hosts is None:
             hosts = self.fengs.keys()
-        unconfigured = [host for host in hosts
-                            if not self.fengs[host].adc_is_configured()]
-        if len(unconfigured) > 0:
-            raise RuntimeError('ADCs not initialized on: %s'
-                               % (','.join(unconfigured)))
+        # Allow sync of unconfigured hosts (just not eth tx) ARP 11/3/21
+        #unconfigured = [host for host in hosts
+        #                    if not self.fengs[host].adc_is_configured()]
+        #if len(unconfigured) > 0:
+        #    raise RuntimeError('ADCs not initialized on: %s'
+        #                       % (','.join(unconfigured)))
         for host in hosts:
             # self.fengs[host].sync.change_period(0) # already done in initialize_dsps
             self.fengs[host].sync.set_delay(0)
@@ -901,9 +902,15 @@ class HeraCorrelator(object):
         self.logger.info('Enabling ethernet output')
         if hosts is None:
             hosts = self.fengs.keys()
+        unconfigured = [host for host in hosts
+                            if not self.fengs[host].adc_is_configured()]
+        if len(unconfigured) > 0:
+            self.logger.warning('Declining to enable eths on unconfigured hosts: %s'
+                               % (','.join(unconfigured)))
         failed = []
         for host in hosts:
             try:
+                assert host not in unconfigured
                 self.fengs[host].eth.enable_tx(verify=verify)
             except(AssertionError):
                 self.logger.warning('Failed to enable %s.eth' % (host)) 


### PR DESCRIPTION
Made correlator initialization able to survive failed snap configuration, but refuse to enable eth tx for failed snaps.