### PR TITLE
add attribute exception trap to get_feng_hostnames

### DIFF
--- a/control_software/src/hera_corr.py
+++ b/control_software/src/hera_corr.py
@@ -322,6 +322,9 @@ class HeraCorrelator(object):
                 if dest_configed and not self.fengs[h].dest_is_configured():
                     continue
                 filtered_hosts.append(h)
+            except AttributeError as e:
+                self.logger.error("Comms failed permanently on %s with error %s" % (h,e.message))
+                raise AttributeError
             except Exception as e:
                 self.logger.warn("Comms failed on %s: %s" % (h, e.message))
         return filtered_hosts


### PR DESCRIPTION
Addresses commissioning issue [#709](https://github.com/HERA-Team/HERA_Commissioning/issues/709)

The error "Comms failed on heraNode9Snap0" originates in hera_corr:get_feng_hostnames.  This function was allowing AttributeError to drop through which leads to creation of a HeraCorr object with no devices on it.  
After this change the script will error allowing systemd to cleanly restart and try again to populate the HERACorr object.