### PR TITLE
Remove eq coeff logging

### DIFF
--- a/control_software/src/blocks.py
+++ b/control_software/src/blocks.py
@@ -1207,11 +1207,14 @@ class Eq(Block):
                          offset=(self.streamsize * stream))
         return data
 
-    def get_status(self, stream):
+    def get_status(self, stream, include_coeffs=False):
         """
         Return the Eq status:  coeffs (per stream) and clip_count (for all)
         """
-        return {'coeffs': self.get_coeffs(stream), 'clip_count': self.clip_count()}
+        if include_coeffs:
+            return {'coeffs': self.get_coeffs(stream), 'clip_count': self.clip_count()}
+        else:
+            return {'clip_count': self.clip_count()}
 
     def get_coeffs(self, stream):
         """

--- a/control_software/src/hera_corr.py
+++ b/control_software/src/hera_corr.py
@@ -329,7 +329,7 @@ class HeraCorrelator(object):
                 self.logger.warn("Comms failed on %s: %s" % (h, e.message))
         return filtered_hosts
 
-    def feng_set_redis_status(self, host):
+    def feng_set_redis_status(self, host, include_eq_coeffs=False):
         """
         Upload SnapFengine.get_status() dict to redis under key
         'status:snap:<host>'.
@@ -337,13 +337,13 @@ class HeraCorrelator(object):
         Inputs:
             host (str): Host to target.
         """
-        status = self.fengs[host].get_status(jsonify_values=True)
+        status = self.fengs[host].get_status(jsonify_values=True, include_eq_coeffs=include_eq_coeffs)
         status['antpols'] = jsonify(self.snap_to_ant[host], True)
         this_key = 'status:snap:{}'.format(host)
         self.r.hmset(this_key, status)
         self.r.expire(this_key, 72 * 3600)
 
-    def set_redis_status_fengs(self, hosts=None,
+    def set_redis_status_fengs(self, hosts=None, include_eq_coeffs=False,
                                multithread=True, timeout=300.):
         """
         Upload status dictionaries to redis for specified hosts.
@@ -357,10 +357,10 @@ class HeraCorrelator(object):
         failed = self._call_on_hosts(
                             target=self.feng_set_redis_status,
                             args=(),
-                            kwargs={},
+                            kwargs={"include_eq_coeffs": include_eq_coeffs},
                             hosts=hosts,
                             multithread=multithread,
-                            timeout=timeout,
+                            timeout=timeout
         )
         return failed
 

--- a/control_software/src/snap_fengine.py
+++ b/control_software/src/snap_fengine.py
@@ -368,7 +368,7 @@ class SnapFengine(object):
         for stream in range(self.input.ninput_mux_streams):
             status['stream%d_autocorr' % stream] = _cdjsonify(self.corr.get_new_corr(stream, stream).real)
         for stream in range(self.eq.nstreams):
-            for key, val in self.eq.get_status(stream, include_eq_coeffs).items():
+            for key, val in self.eq.get_status(stream, include_coeffs=include_eq_coeffs).items():
                 if key == 'clip_count':  # There is only one of these per snap.
                     status['eq_%s' % key] = _cdjsonify(val)
                 else:

--- a/control_software/src/snap_fengine.py
+++ b/control_software/src/snap_fengine.py
@@ -332,7 +332,7 @@ class SnapFengine(object):
         else:
             return inputs
 
-    def get_status(self, jsonify_values=False):
+    def get_status(self, jsonify_values=False, include_eq_coeffs=False):
         '''Return dict of config status.'''
         _cdjsonify = lambda val: jsonify(val, cast=jsonify_values)
         status = {}
@@ -368,7 +368,7 @@ class SnapFengine(object):
         for stream in range(self.input.ninput_mux_streams):
             status['stream%d_autocorr' % stream] = _cdjsonify(self.corr.get_new_corr(stream, stream).real)
         for stream in range(self.eq.nstreams):
-            for key, val in self.eq.get_status(stream).items():
+            for key, val in self.eq.get_status(stream, include_eq_coeffs).items():
                 if key == 'clip_count':  # There is only one of these per snap.
                     status['eq_%s' % key] = _cdjsonify(val)
                 else:


### PR DESCRIPTION
This adds a flag to include eq coefficients in the snap status logging, which had previously been the only option.  The default here is to NOT include them.  The flag is plumbed out to hera_corr.py, but not to the snap-redis-monitor-script, which will use the default of not including.