### PR TITLE
Monitor update

### DIFF
--- a/control_software/scripts/hera_snap_redis_monitor.py
+++ b/control_software/scripts/hera_snap_redis_monitor.py
@@ -8,6 +8,7 @@ import socket
 import logging
 import argparse
 from os import path as op
+import sys
 from datetime import datetime
 
 from hera_corr_f import HeraCorrelator, __version__, __package__
@@ -15,7 +16,6 @@ from hera_corr_cm.handlers import add_default_log_handlers
 
 logger = add_default_log_handlers(logging.getLogger(__file__))
 hostname = socket.gethostname()
-
 
 def print_ant_log_messages(corr):
     for ant, antval in corr.ant_to_snap.iteritems():
@@ -44,10 +44,6 @@ if __name__ == "__main__":
                         help='Hosts to monitor (None uses all).')
     parser.add_argument('-r', dest='redishost', type=str, default='redishost',
                         help='Host servicing redis requests')
-    parser.add_argument('-d', dest='delay', type=float, default=10.0,
-                        help='Seconds between polling loops')
-    parser.add_argument('-D', dest='retrytime', type=float, default=300.0,
-                        help='Seconds between reconnection attempts to dead boards')
     parser.add_argument('-l', dest='loglevel', type=str, default="INFO",
                         help='Log level. DEBUG / INFO / WARNING / ERROR',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'])
@@ -61,45 +57,18 @@ if __name__ == "__main__":
         args.hosts = args.hosts.split(',')
 
     corr = HeraCorrelator(hosts=args.hosts, redishost=args.redishost, block_monitoring=False)
-    upload_time = corr.r.hget('snap_configuration', 'upload_time')
     if args.verbose:
         print_ant_log_messages(corr)
 
-    retry_tick = time.time()
     script_redis_key = "status:script:{:s}:{:s}".format(hostname, __file__)
-    locked_out = False
     logger.info('Starting SNAP redis monitor')
 
-    counter = 0
-    while(True):
-        tick = time.time()
-        counter += 1
-        if args.verbose:
-            print("Tick {}:  {}".format(counter, datetime.now().isoformat()))
-        corr.r.set(script_redis_key, "alive", ex=max(60, args.delay * 2))
-        while corr.r.exists('disable_monitoring'):
-            if not locked_out:
-                logger.warning('Monitoring locked out by {}. Retrying every 10 seconds'
-                               .format(corr.r.get('disable_monitoring')))
-                locked_out = True
-            corr.r.set(script_redis_key, "locked out", ex=20)
-            time.sleep(10)
-        if locked_out:
-            logger.warning('Monitoring unlocked')
-            locked_out = False
+    corr.r.set(script_redis_key, "alive", ex=max(60, args.delay * 2))
 
-        # Check for a new configuration, and if one exists, update the Fengine list
-        if corr.r.hget('snap_configuration', 'upload_time') != upload_time:
-            upload_time = corr.r.hget('snap_configuration', 'upload_time')
-            logger.info('New configuration detected. Reinitializing fengine list')
-            corr = HeraCorrelator(redishost=args.redishost, block_monitoring=False)
-            if args.verbose:
-                print_ant_log_messages(corr)
-
-        # Recompute the hookup every time. It's fast
-        corr._hookup_from_redis()
-
-        # load this module's version into redis
+    if corr.r.exists('disable_monitoring'):
+        logger.warning('Monitoring locked out by {}.'
+                           .format(corr.r.get('disable_monitoring')))
+    else:
         corr.r.hmset(
             "version:{:s}:{:s}".format(__package__, op.basename(__file__)),
             {"version": __version__, "timestamp": datetime.now().isoformat()}
@@ -110,16 +79,3 @@ if __name__ == "__main__":
             corr.set_redis_status_fengs()
         except Exception as e:
             logger.warning(str(e))
-
-        # If the retry period has been exceeded, try to reconnect to dead boards:
-        if time.time() > (retry_tick + args.retrytime):
-            if len(corr._unconnected) > 0:
-                logger.debug('Trying to reconnect to unreachable boards')
-                corr._unconnected = corr.connect_fengs(hosts=corr._unconnected)
-                retry_tick = time.time()
-
-        # If executing the loop hasn't already taken longer than the loop delay time add extra wait.
-        extra_delay = args.delay - (time.time() - tick)
-        if extra_delay > 0:
-            logger.debug("Sleeping for {:.2f} seconds".format(extra_delay))
-            time.sleep(extra_delay)


### PR DESCRIPTION
Overhaul of hera_snap_redis_monitor.py to run one-off when called by crontab every ~10 m. Should be more robust and stable. Deployed on site and runs successfully.