### PR TITLE
include snap_start.log to redis

### DIFF
--- a/control_software/scripts/hera_feng_start.sh
+++ b/control_software/scripts/hera_feng_start.sh
@@ -16,7 +16,7 @@ Help()
 maxeth="44"
 
 # Process input arguments
-while getopts "m:" option; do
+while getopts "hm:" option; do
     case $option in
         h) # display Help
             Help

--- a/control_software/scripts/hera_feng_start.sh
+++ b/control_software/scripts/hera_feng_start.sh
@@ -5,9 +5,34 @@ LOGFILE=~/snap_start.log
 source ~/.bashrc
 set -e
 
-echo hera_feng_start.sh: Initializing F-Engines > $LOGFILE
+Help()
+{
+    echo "Options:"
+    echo "m     Maximum SNAP ethernets to enable. Default 44"
+    echo
+}
+
+# Default values
+maxeth="44"
+
+# Process input arguments
+while getopts "m:" option; do
+    case $option in
+        h) # display Help
+            Help
+            exit;;
+        m) # maxeth
+            maxeth="$OPTARG"
+            ;;
+        \?) # Invalid option
+            Help
+            exit;;
+    esac
+done
+
+echo hera_feng_start.sh: Initializing up to ${maxeth} F-Engines > $LOGFILE
 date >> $LOGFILE
-hera_snap_feng_init.py -p -i -d -s -e --max_eth_enabled=46 &>> $LOGFILE
+hera_snap_feng_init.py -p -i -d -s -e --max_eth_enabled=${maxeth} &>> $LOGFILE
 
 echo >> $LOGFILE
 echo >> $LOGFILE

--- a/control_software/scripts/hera_feng_start_maintenance.sh
+++ b/control_software/scripts/hera_feng_start_maintenance.sh
@@ -12,6 +12,7 @@ Help()
    echo "f     FEM switch: antenna (default), load, noise"
    echo "h     This help"
    echo "s     Digital noise seed: same (default), diff"
+   echo "m     Maximum SNAP ethernets to enable. Default 44"
    echo
 }
 
@@ -19,9 +20,10 @@ Help()
 input="adc"
 fem="antenna"
 seed="same"
+maxeth="44"
 
 # Process input arguments
-while getopts "hf:d:s:" option; do
+while getopts "hf:d:s:m:" option; do
     case $option in
       h) # display Help
          Help
@@ -35,16 +37,19 @@ while getopts "hf:d:s:" option; do
       s) # seed state
          seed="$OPTARG"
          ;;
+      m) # maxeth
+         maxeth="$OPTARG"
+         ;;
      \?) # Invalid option
          Help
          exit;;
     esac
 done
 
-echo hera_feng_start.sh: Initializing F-Engines > $LOGFILE
+echo hera_feng_start.sh: Initializing up to ${maxeth} F-Engines > $LOGFILE
 date >> $LOGFILE
-echo hera_snap_feng_init.py -p -i -d --fem_state=${fem} --snap_source=${input} --snap_seed=${seed} -s -e --max_eth_enabled=46 >> $LOGFILE
-hera_snap_feng_init.py -p -i -d --fem_state=${fem} --snap_source=${input} --snap_seed=${seed} -s -e --max_eth_enabled=46 &>> $LOGFILE
+echo hera_snap_feng_init.py -p -i -d --fem_state=${fem} --snap_source=${input} --snap_seed=${seed} -s -e --max_eth_enabled=${maxeth} >> $LOGFILE
+hera_snap_feng_init.py -p -i -d --fem_state=${fem} --snap_source=${input} --snap_seed=${seed} -s -e --max_eth_enabled=${maxeth} &>> $LOGFILE
 echo hera_feng_start.sh: Synchronized and Started TX >> $LOGFILE
 
 hera_snap_enable_monitors.py

--- a/control_software/scripts/hera_snap_feng_init.py
+++ b/control_software/scripts/hera_snap_feng_init.py
@@ -1,7 +1,7 @@
 #!/home/hera/anaconda2/envs/venv/bin/python
 
 import argparse
-from hera_corr_f import HeraCorrelator, __version__
+from hera_corr_f import HeraCorrelator, __version__, snap_start_log_to_redis
 from hera_corr_cm import handlers
 import time
 import logging
@@ -218,3 +218,7 @@ def main():
 
 if __name__ == "__main__":
     main()
+    snap_log = snap_start_log_to_redis.SnapLog('/home/hera/snap_start.log')
+    snap_log.load()
+    snap_log.split()
+    snap_log.redis()

--- a/control_software/src/snap_start_log_to_redis.py
+++ b/control_software/src/snap_start_log_to_redis.py
@@ -1,0 +1,107 @@
+import datetime
+import redis
+
+
+class SnapLog:
+    log_designators = ['INFO', 'WARNING', 'ERROR']
+
+    def __init__(self, fname):
+        self.fname = fname
+
+    def load(self):
+        self.log = {}
+        for ld in self.log_designators:
+            self.log[ld] = {}
+        dtime = None
+        with open(self.fname, 'r') as fp:
+            for line in fp:
+                for this_des in self.log:
+                    if this_des in line:
+                        break
+                else:
+                    continue
+                hostnames = []
+                for node in range(30):
+                    for loc in range(4):
+                        hostname = "heraNode{}Snap{}".format(node, loc)
+                        if hostname in line:
+                            hostnames.append(hostname)
+                if not len(hostnames):
+                    if 'Sync passed' in line:
+                        hostnames = ['Sync passed']
+                    elif 'Initialization complete' in line:
+                        hostnames = ['Initialization complete']
+                for this_hostname in hostnames:
+                    self.log[this_des].setdefault(this_hostname, {})
+                    try:
+                        dtime = datetime.datetime.strptime(line[:19], "%Y-%m-%d %H:%M:%S")
+                        ms = float(line.split('-')[2].split(',')[-1])
+                        dtime += datetime.timedelta(milliseconds=ms)
+                    except ValueError:
+                        if dtime is None:
+                            continue
+                        else:
+                            dtime = dtime
+                    if dtime in self.log[this_des][this_hostname]:
+                        dtime += datetime.timedelta(microseconds=1.0)
+                    self.log[this_des][this_hostname][dtime] = line.strip()
+
+    def split(self):
+        self.working = []
+        self.unconfig = []
+        self.maxout = []
+        self.commfail = set()
+        self.log_time_start, self.log_time_stop = None, None
+
+        if 'Sync passed' in self.log['INFO']:
+            self.log_time_start = sorted(self.log['INFO']['Sync passed'].keys())[-1]
+        if 'Initialization complete' in self.log['INFO']:
+            self.log_time_stop = sorted(self.log['INFO']['Initialization complete'].keys())[-1]
+        if self.log_time_start is None or self.log_time_stop is None:
+            return
+
+        ts = {}
+        for ld in self.log.keys():
+            for th in self.log[ld].keys():
+                for dt in self.log[ld][th].keys():
+                    if dt >= self.log_time_start and dt <= self.log_time_stop:
+                        this_line = self.log[ld][th][dt]
+                        while dt in ts:
+                            dt += datetime.timedelta(microseconds=1.0)
+                        ts.setdefault(th, {})
+                        ts[th][dt] = this_line
+        for hostname in ts.keys():
+            is_working = False
+            for dt in sorted(ts[hostname]):
+                line = ts[hostname][dt]
+                is_working = False
+                if 'Arming sync' in line:
+                    is_working = True
+                elif 'Not enabling eths on unconfiged hosts:' in line:
+                    self.unconfig.append(hostname)
+                elif 'Max enabled reached: not enabling' in line:
+                    self.maxout.append(hostname)
+                elif 'Comms failed on' in line:
+                    self.commfail.add(hostname)
+            if is_working:
+                self.working.append(hostname)
+
+    def redis(self):
+        connection_pool = redis.ConnectionPool(host='redishost', decode_responses=True)
+        r = redis.StrictRedis(connection_pool=connection_pool)
+        try:
+            log_time_start = self.log_time_start.strftime('%Y-%m-%dT%H:%M:%S.%f')
+        except AttributeError:
+            log_time_start = 'Not found'
+        try:
+            log_time_stop = self.log_time_stop.strftime('%Y-%m-%dT%H:%M:%S.%f')
+        except AttributeError:
+            log_time_start = 'Not found'
+        stat = {'timestamp': datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S'),
+                'log_time_start': log_time_start,
+                'log_time_stop': log_time_stop,
+                'working': ','.join(self.working),
+                'unconfig': ','.join(self.unconfig),
+                'maxout': ','.join(self.maxout),
+                'commfail': ','.join(self.commfail)}
+        r.hmset('snap_log', stat)


### PR DESCRIPTION
This includes the action to log items from `snap_start.log` to redis after `hera_feng_init.py` is run.  It still just goes through the file to get the content into redis, rather than having the initialize do it directly, but this at least will log after and when the fengs are inited rather than just on a cron job.