### PR TITLE
Trap dig sync fail

### DIFF
--- a/control_software/scripts/hera_feng_start.sh
+++ b/control_software/scripts/hera_feng_start.sh
@@ -32,7 +32,7 @@ done
 
 echo hera_feng_start.sh: Initializing up to ${maxeth} F-Engines > $LOGFILE
 date >> $LOGFILE
-hera_snap_feng_init.py -p -i -d -s -e --max_eth_enabled=${maxeth} &>> $LOGFILE
+hera_snap_feng_init.py -p -i -D -s -e --max_eth_enabled=${maxeth} &>> $LOGFILE
 
 echo >> $LOGFILE
 echo >> $LOGFILE

--- a/control_software/scripts/hera_snap_feng_init.py
+++ b/control_software/scripts/hera_snap_feng_init.py
@@ -187,8 +187,12 @@ def main():
 
         # Select SNAP F-Engine input to be adc or digital noise
         init_time = time.time()
-        failed = corr.set_input_fengs(source=args.snap_source, seed=args.snap_seed)
-        warn_failed(logger, failed, 'set_input_fengs', all_snaps=args.allsnaps)
+        try:
+            failed = corr.set_input_fengs(source=args.snap_source, seed=args.snap_seed)
+            warn_failed(logger, failed, 'set_input_fengs', all_snaps=args.allsnaps)
+        except(RuntimeError):
+            logger.warning("Digital Noise Sync Failed!")
+
 
         # Sync logic. Do global sync first, and then noise generators
         # wait for a PPS to pass then arm all the boards

--- a/control_software/scripts/hera_snap_feng_init.py
+++ b/control_software/scripts/hera_snap_feng_init.py
@@ -194,7 +194,13 @@ def main():
         # wait for a PPS to pass then arm all the boards
         if args.sync:
             #corr.disable_eths() # ARP: no need to disable, and keeping them enabled reduces risk of them going incommunicado
-            corr.sync()
+            synced = False
+            while not synced:
+                try:
+                    corr.sync()
+                    synced = True
+                except(RuntimeError):
+                    logger.warning('Synchronization failed. Retrying...')
 
         if args.eth:
             failed = corr.enable_eths(max_enabled=args.max_eth_enabled)


### PR DESCRIPTION
Had a sync fail  when setting inputs to dig or adc.  We prefer to soldier on if this happens. This pr traps the RuntimeError.

Installed and running on site.